### PR TITLE
Encode decode performance improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,9 @@ To run tests, call:
 
 To run benchmarks, call:
 
-    $ make benchmark
+    $ make bench
+
+## Latest benchmarks
+
+    BenchmarkEncode-4        5000000           387 ns/op         109 B/op          5 allocs/op
+    BenchmarkDecode-4        5000000           302 ns/op          19 B/op          2 allocs/op

--- a/README.md
+++ b/README.md
@@ -35,5 +35,5 @@ To run benchmarks, call:
 
 ## Latest benchmarks
 
-    BenchmarkEncode-4        5000000           387 ns/op         109 B/op          5 allocs/op
+    BenchmarkEncode-4        5000000           342 ns/op         109 B/op          5 allocs/op
     BenchmarkDecode-4        5000000           302 ns/op          19 B/op          2 allocs/op

--- a/README.md
+++ b/README.md
@@ -35,5 +35,9 @@ To run benchmarks, call:
 
 ## Latest benchmarks
 
-    BenchmarkEncode-4        5000000           342 ns/op         109 B/op          5 allocs/op
-    BenchmarkDecode-4        5000000           302 ns/op          19 B/op          2 allocs/op
+    BenchmarkEncodeLevel2-4    	 5000000	       327 ns/op	      88 B/op	       5 allocs/op
+    BenchmarkEncodeLevel6-4    	 5000000	       356 ns/op	      96 B/op	       5 allocs/op
+    BenchmarkEncodeLevel15-4   	 3000000	       428 ns/op	     144 B/op	       5 allocs/op
+    BenchmarkDecodeLevel2-4    	 5000000	       298 ns/op	      19 B/op	       2 allocs/op
+    BenchmarkDecodeLevel6-4    	 5000000	       313 ns/op	      19 B/op	       2 allocs/op
+    BenchmarkDecodeLevel15-4   	 5000000	       347 ns/op	      19 B/op	       2 allocs/op

--- a/v3/geohex.go
+++ b/v3/geohex.go
@@ -6,6 +6,9 @@ import (
 
 const VERSION = "3.0.0"
 
+// MaxLevel is the maximum encoding level that this implementation supports
+const MaxLevel = 20
+
 var (
 	hChars = []byte{'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'}
 	hIndex = make(map[byte]int, len(hChars))
@@ -55,7 +58,7 @@ func (ll *LL) Point() *Point {
 
 // Init zooms
 func init() {
-	for level := 0; level < 21; level++ {
+	for level := 0; level <= MaxLevel; level++ {
 		size := hBase / math.Pow(3, float64(level+3))
 		zooms[level] = &Zoom{level: level, size: size, scale: size / hEr, w: 6 * size, h: 6 * size * hK}
 	}

--- a/v3/geohex_test.go
+++ b/v3/geohex_test.go
@@ -3,27 +3,73 @@ package geohex
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"math/rand"
 	"testing"
 )
+
+const testItems = 30
+
+var (
+	randomGenerator = rand.New(rand.NewSource(0))
+	points          [testItems][2]float64
+	geohex2         [testItems]string
+	geohex6         [testItems]string
+	geohex15        [testItems]string
+)
+
+func init() {
+	for i := 0; i < testItems; i++ {
+		points[i] = [2]float64{randomGenerator.Float64()*180 - 90, randomGenerator.Float64()*360 - 180}
+		zone2, _ := Encode(points[i][0], points[i][1], 2)
+		geohex2[i] = zone2.String()
+		zone6, _ := Encode(points[i][0], points[i][1], 6)
+		geohex6[i] = zone6.String()
+		zone15, _ := Encode(points[i][0], points[i][1], 15)
+		geohex15[i] = zone15.String()
+	}
+}
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "geohex")
 }
 
-func BenchmarkEncode(b *testing.B) {
-	for i := 0; i < b.N; i += 3 {
-		Encode(7.092954137951794, 179.9073230957031, 2)
-		Encode(-21.616579336740593, -166.9921875, 6)
-		Encode(82.07002819448266, -177.890625, 15)
+func BenchmarkEncodeLevel2(b *testing.B) {
+	for i := 0; i < b.N; i += 1 {
+		p := points[i%testItems]
+		Encode(p[0], p[1], 2)
 	}
 }
 
-func BenchmarkDecode(b *testing.B) {
-	for i := 0; i < b.N; i += 3 {
-		Decode("QU08")
-		Decode("GH501658")
-		Decode("TK720137660817775")
+func BenchmarkEncodeLevel6(b *testing.B) {
+	for i := 0; i < b.N; i += 1 {
+		p := points[i%testItems]
+		Encode(p[0], p[1], 6)
+	}
+}
+
+func BenchmarkEncodeLevel15(b *testing.B) {
+	for i := 0; i < b.N; i += 1 {
+		p := points[i%testItems]
+		Encode(p[0], p[1], 15)
+	}
+}
+
+func BenchmarkDecodeLevel2(b *testing.B) {
+	for i := 0; i < b.N; i += 1 {
+		Decode(geohex2[i%testItems])
+	}
+}
+
+func BenchmarkDecodeLevel6(b *testing.B) {
+	for i := 0; i < b.N; i += 1 {
+		Decode(geohex6[i%testItems])
+	}
+}
+
+func BenchmarkDecodeLevel15(b *testing.B) {
+	for i := 0; i < b.N; i += 1 {
+		Decode(geohex15[i%testItems])
 	}
 }
 

--- a/v3/zone.go
+++ b/v3/zone.go
@@ -3,6 +3,7 @@ package geohex
 import (
 	"fmt"
 	"math"
+	"strconv"
 )
 
 // Error types
@@ -105,7 +106,12 @@ func Decode(code string) (_ *LL, err error) {
 	}
 
 	pos := &Position{z: zoom}
-	code = fmt.Sprintf("%03d", n1*30+n2) + code[2:]
+	base := n1*30 + n2
+	if base < 100 {
+		code = "0" + strconv.Itoa(base) + code[2:]
+	} else {
+		code = strconv.Itoa(base) + code[2:]
+	}
 	for i, digit := range code {
 		n := int64(digit - '0')
 		if n < 0 || n > 9 {

--- a/v3/zone.go
+++ b/v3/zone.go
@@ -72,16 +72,19 @@ func Encode(lat, lon float64, level int) (_ *Zone, err error) {
 		}
 
 		num := c3x*3 + c3y
-		if i < 3 {
-			base += int(math.Pow(10, float64(2-i))) * num
+		if i == 0 {
+			base += 100 * num
+		} else if i == 1 {
+			base += 10 * num
+		} else if i == 2 {
+			base += num
 		} else {
 			code[i-1] = '0' + byte(num)
 		}
 	}
 
-	basef := float64(base)
-	code[0] = hChars[int(math.Floor(basef/30))]
-	code[1] = hChars[int(math.Floor(math.Mod(basef, 30)))]
+	code[0] = hChars[base/30]
+	code[1] = hChars[base%30]
 
 	return &Zone{Code: string(code), Pos: pos}, nil
 }

--- a/v3/zone.go
+++ b/v3/zone.go
@@ -3,7 +3,6 @@ package geohex
 import (
 	"fmt"
 	"math"
-	"strconv"
 )
 
 // Error types
@@ -70,7 +69,7 @@ func Encode(lat, lon float64, level int) (_ *Zone, err error) {
 		if i < 3 {
 			base += int(math.Pow(10, float64(2-i))) * num
 		} else {
-			code[i-1] = strconv.Itoa(num)[0]
+			code[i-1] = '0' + byte(num)
 		}
 	}
 
@@ -99,23 +98,25 @@ func Decode(code string) (_ *LL, err error) {
 	pos := &Position{z: zoom}
 	code = fmt.Sprintf("%03d", n1*30+n2) + code[2:]
 	for i, digit := range code {
-		var n int64
-		if n, err = strconv.ParseInt(string(digit), 10, 32); err != nil {
+		n := int64(digit - '0')
+		if n < 0 || n > 9 {
+			err = fmt.Errorf("expected a digit, got '%s'", digit)
 			return
 		}
 
 		pow := int(math.Pow(3, float64(lnc-i)))
-		sb2 := fmt.Sprintf("%02s\n", strconv.FormatInt(n, 3))
-		switch sb2[0] {
-		case '0':
+		c3x := n / 3
+		c3y := n % 3
+		switch c3x {
+		case 0:
 			pos.X -= pow
-		case '2':
+		case 2:
 			pos.X += pow
 		}
-		switch sb2[1] {
-		case '0':
+		switch c3y {
+		case 0:
 			pos.Y -= pow
-		case '2':
+		case 2:
 			pos.Y += pow
 		}
 	}

--- a/v3/zone.go
+++ b/v3/zone.go
@@ -17,6 +17,12 @@ type Zone struct {
 	Pos  *Position
 }
 
+var (
+	// Precalculated math stuff
+	pow3f [MaxLevel + 3]float64
+	pow3i [MaxLevel + 3]int
+)
+
 // String returns the zone code
 func (z *Zone) String() string {
 	return z.Code
@@ -45,7 +51,7 @@ func Encode(lat, lon float64, level int) (_ *Zone, err error) {
 	base, code := 0, make([]byte, level+2)
 
 	for i := 0; i < level+3; i++ {
-		pow := math.Pow(3, float64(level+2-i))
+		pow := pow3f[level+2-i]
 		p2c := math.Ceil(pow / 2)
 		c3x, c3y := 1, 1
 
@@ -104,7 +110,7 @@ func Decode(code string) (_ *LL, err error) {
 			return
 		}
 
-		pow := int(math.Pow(3, float64(lnc-i)))
+		pow := pow3i[lnc-i]
 		c3x := n / 3
 		c3y := n % 3
 		switch c3x {
@@ -122,4 +128,11 @@ func Decode(code string) (_ *LL, err error) {
 	}
 
 	return pos.LL(), nil
+}
+
+func init() {
+	for i := 0; i < MaxLevel+3; i++ {
+		pow3f[i] = math.Pow(3, float64(i))
+		pow3i[i] = int(math.Pow(3, float64(i)))
+	}
 }

--- a/v3/zone.go
+++ b/v3/zone.go
@@ -105,13 +105,14 @@ func Decode(code string) (_ *LL, err error) {
 		return nil, ErrCodeInvalid
 	}
 
-	pos := &Position{z: zoom}
 	base := n1*30 + n2
 	if base < 100 {
 		code = "0" + strconv.Itoa(base) + code[2:]
 	} else {
 		code = strconv.Itoa(base) + code[2:]
 	}
+
+	pos := &Position{z: zoom}
 	for i, digit := range code {
 		n := int64(digit - '0')
 		if n < 0 || n > 9 {


### PR DESCRIPTION
This improves a lot the performance of `Encode` and `Decode` functions, original benchmarks on my computer were:
```
BenchmarkEncode-4   	 1000000	      1270 ns/op	     120 B/op	      12 allocs/op
BenchmarkDecode-4   	  300000	      4363 ns/op	     314 B/op	      45 allocs/op
```
Now they are:
```
BenchmarkEncode-4   	 5000000	       341 ns/op	     109 B/op	       5 allocs/op
BenchmarkDecode-4   	 5000000	       310 ns/op	      19 B/op	       2 allocs/op
```
Which is a 3x improvement in `Encode` and 13x in `Decode`

Additionally, benchmarks were split into different levels, and I added more points to be encoded/decoded (avoiding any processor-level caching that could be applied).
With those benchmarks, original version benchmarked:
```
BenchmarkEncodeLevel2-4    	 2000000	       761 ns/op	      92 B/op	       7 allocs/op
BenchmarkEncodeLevel6-4    	 1000000	      1258 ns/op	     104 B/op	      11 allocs/op
BenchmarkEncodeLevel15-4   	  500000	      2490 ns/op	     159 B/op	      20 allocs/op
BenchmarkDecodeLevel2-4    	 1000000	      2279 ns/op	     164 B/op	      23 allocs/op
BenchmarkDecodeLevel6-4    	  500000	      3791 ns/op	     269 B/op	      39 allocs/op
BenchmarkDecodeLevel15-4   	  200000	      7365 ns/op	     507 B/op	      75 allocs/op
```
It's clear that time growth is almost linear with the level being encoded/decoded. With this changes it's almost constant (most of time time is wasted on calculating Mercator projection & point coordinates which is constant, then obviously encoding/decoding is linear but it's just a small fraction):
```
BenchmarkEncodeLevel2-4    	 5000000	       328 ns/op	      88 B/op	       5 allocs/op
BenchmarkEncodeLevel6-4    	 5000000	       356 ns/op	      96 B/op	       5 allocs/op
BenchmarkEncodeLevel15-4   	 3000000	       431 ns/op	     144 B/op	       5 allocs/op
BenchmarkDecodeLevel2-4    	 5000000	       295 ns/op	      19 B/op	       2 allocs/op
BenchmarkDecodeLevel6-4    	 5000000	       311 ns/op	      19 B/op	       2 allocs/op
BenchmarkDecodeLevel15-4   	 5000000	       355 ns/op	      19 B/op	       2 allocs/op
```