### PR TITLE
Implemented  method for position fixing after decoding

### DIFF
--- a/v3/zone.go
+++ b/v3/zone.go
@@ -79,7 +79,7 @@ func DecodePosition(code string) (*Position, error) {
 		code = strconv.Itoa(base) + code[2:]
 	}
 
-	pos := &Position{z: zoom}
+	var x, y int
 	for i, digit := range code {
 		n := int64(digit - '0')
 		if n < 0 || n > 9 {
@@ -91,18 +91,31 @@ func DecodePosition(code string) (*Position, error) {
 		c3y := n % 3
 		switch c3x {
 		case 0:
-			pos.X -= pow
+			x -= pow
 		case 2:
-			pos.X += pow
+			x += pow
 		}
 		switch c3y {
 		case 0:
-			pos.Y -= pow
+			y -= pow
 		case 2:
-			pos.Y += pow
+			y += pow
 		}
 	}
-	return pos, nil
+
+	hsteps := int(math.Abs(float64(x - y)))
+	if pow3[lnc] == hsteps && x > y {
+		x, y = y, x //
+	} else if hsteps > pow3[lnc] {
+		dif := hsteps - pow3[lnc]
+		if x > y {
+			x, y = y+dif, x-dif
+		} else if y > x {
+			x, y = y-dif, x+dif
+		}
+	}
+
+	return &Position{X: x, Y: y, z: zoom}, nil
 
 }
 

--- a/v3/zone_test.go
+++ b/v3/zone_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Decode LatLon from Code", func() {
 var _ = Describe("Decode Position from Code", func() {
 
 	for _, tc := range loadCode2PositionTestCases() {
-		tc := &tc
+		tc := tc
 		It(fmt.Sprintf("should decode position [%d, %d] from %s", tc.expectedPosition.X, tc.expectedPosition.Y, tc.code), func() {
 			act, err := DecodePosition(tc.code)
 			Expect(err).To(BeNil())


### PR DESCRIPTION
I've implemented this method from the original library, this fixes the position decoding tests:
```javascript
function adjustXY(_x, _y, _level){
	var x =_x;
	var y =_y;
	var rev = 0;
	var max_hsteps = Math.pow(3,_level+2);
	var hsteps = Math.abs(x - y);
	if(hsteps==max_hsteps&&x>y){
		var tmp = x;
		x = y;
		y = tmp;
		rev =1;
	}else if(hsteps>max_hsteps){
		var dif = hsteps - max_hsteps;
		var dif_x = Math.floor(dif/2);
		var dif_y = dif - dif_x;
		var edge_x;
		var edge_y;
		if(x>y){
			edge_x = x - dif_x;
			edge_y = y + dif_y;
			var h_xy = edge_x;
			edge_x = edge_y;
			edge_y = h_xy;
			x = edge_x + dif_x;
			y = edge_y - dif_y;
		}else if(y>x){
			edge_x = x + dif_x;
			edge_y = y - dif_y;
			var h_xy = edge_x;
			edge_x = edge_y;
			edge_y = h_xy;
			x = edge_x - dif_x;
			y = edge_y + dif_y;
		}
	}
	return { x: x, y: y , rev:rev};
}
```
I'm already working on another branch moving a lot of things, but this is a quick way of fixing `master`.