### PR TITLE
Reverted 'cabify' package from README's example

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ GeoHex implementation in Go
 import (
 	"fmt"
 
-	geohex "github.com/cabify/go-geohex/v3"
+	geohex "github.com/bsm/go-geohex/v3"
 )
 
 func ExampleEncode() {


### PR DESCRIPTION
Sorry for this... 
I had this package written in my example_test.go in order to be able to run tests without having it in your master, then I fixed the example_test.go at some point but forgot about this one :)